### PR TITLE
Critical fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Initially built on top of CommunityToolkit popups version one, it was found to b
 - **🔄 HotReload Support**: Preview changes in realtime
 ---
 
+## ⬆️ What's New 1.10.2.1
+
+* **iOS crash fix when simultaineously opening/closing** - when one is closing and the second one is opening, now the second one would open only after the closing one finished cleaning up.
+
+---
+
 ## ⬆️ What's New 1.10.1.1
 
 * **Added support for .NET 10** by [yurkinh](https://github.com/yurkinh).

--- a/README.md
+++ b/README.md
@@ -24,17 +24,9 @@ Initially built on top of CommunityToolkit popups version one, it was found to b
 ## ⬆️ What's New 1.10.2.1
 
 * **iOS crash fix when simultaineously opening/closing** - when one is closing and the second one is opening, now the second one would open only after the closing one finished cleaning up.
-
----
-
-## ⬆️ What's New 1.10.1.1
-
-* **Added support for .NET 10** by [yurkinh](https://github.com/yurkinh).
-* **Whirl hide rotation direction fixed on Android and Windows**: The `Whirl` animation was rotating in the same clockwise direction on both show and hide. Hide now rotates counter-clockwise (reverse of show), matching iOS behavior.
-* **Sprint show alpha flash fixed on Android**: `SprintBottom`, `SprintTop`, `SprintLeft`, `SprintRight` were setting initial alpha to `1` (fully visible) before the show animation started from `0.5`, causing a brief visible flash. Initial alpha is now correctly `0.5` for all Sprint types, matching iOS.
-* **Sprint show opacity mismatch fixed on Windows**: Sprint show animations set `Opacity = 0.5` initially but the storyboard animation started `From = 0`, causing an immediate jump to transparent at animation start. Animation now correctly starts `From = 0.5`.
-* **DisplayMode change fix for Windows**: Popup now re-opens at correct position on Windows when changing `DisplayMode`, matching other platforms.
-* **Fixes for SampleApp**: Removed Anchored popup limited height.
+* **Android crash fix — `JavaProxyThrowable` on touch after dismiss**: Added the required `(IntPtr, JniHandleOwnership)` JNI resurrection constructor to `MauiPopup`. Without it, `TypeManager.CreateInstance` crashed whenever Android dispatched a touch event to a still-alive native Dialog whose managed C# peer had already been disposed. Added `[Preserve(AllMembers = true)]` so the release-mode linker cannot strip the JNI type registration. Also removed the premature `Dispose()` call in `CleanupExistingDialog` that raced with queued native events, and cleared the `SetOnCancelListener` on cleanup to prevent late-firing callbacks into a cleaned-up instance.
+* **iOS memory leak fix — `UITapGestureRecognizer` never removed**: The tap gesture recognizer added to the popup view in `CreateControl` was never removed on close, creating a retain cycle (`View → tapGesture → closure → MauiPopup → View`) that kept the popup object alive after dismissal. The recognizer is now stored and explicitly removed and disposed in `CleanUp()`. Also removed a redundant null-guard `throw` that was dead code inside an already-null-checked branch.
+* **Windows double-close fix — `PopupView.Closed` fired during cleanup**: In `SetElement(null)`, `PopupView.IsOpen = false` was set before `PopupView.Closed -= OnClosed`. Because WinUI fires `Popup.Closed` synchronously, `OnClosed` fired while `VirtualView` was still set, invoking `MapOnDismissedByTappingOutsideOfPopup` and triggering a second disconnect on every normal close. The unsubscribe is now done before setting `IsOpen = false`. Also cleared the `overlay` reference in `SetElement(null)` and added a null guard in `OnSizeChanged` for `Content`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Initially built on top of CommunityToolkit popups version one, it was found to b
 
 ## ⬆️ What's New 1.10.2.1
 
-* **iOS crash fix when simultaineously opening/closing** - when one is closing and the second one is opening, now the second one would open only after the closing one finished cleaning up.
-* **Android crash fix — `JavaProxyThrowable` on touch after dismiss**: Added the required `(IntPtr, JniHandleOwnership)` JNI resurrection constructor to `MauiPopup`. Without it, `TypeManager.CreateInstance` crashed whenever Android dispatched a touch event to a still-alive native Dialog whose managed C# peer had already been disposed. Added `[Preserve(AllMembers = true)]` so the release-mode linker cannot strip the JNI type registration. Also removed the premature `Dispose()` call in `CleanupExistingDialog` that raced with queued native events, and cleared the `SetOnCancelListener` on cleanup to prevent late-firing callbacks into a cleaned-up instance.
-* **iOS memory leak fix — `UITapGestureRecognizer` never removed**: The tap gesture recognizer added to the popup view in `CreateControl` was never removed on close, creating a retain cycle (`View → tapGesture → closure → MauiPopup → View`) that kept the popup object alive after dismissal. The recognizer is now stored and explicitly removed and disposed in `CleanUp()`. Also removed a redundant null-guard `throw` that was dead code inside an already-null-checked branch.
-* **Windows double-close fix — `PopupView.Closed` fired during cleanup**: In `SetElement(null)`, `PopupView.IsOpen = false` was set before `PopupView.Closed -= OnClosed`. Because WinUI fires `Popup.Closed` synchronously, `OnClosed` fired while `VirtualView` was still set, invoking `MapOnDismissedByTappingOutsideOfPopup` and triggering a second disconnect on every normal close. The unsubscribe is now done before setting `IsOpen = false`. Also cleared the `overlay` reference in `SetElement(null)` and added a null guard in `OnSizeChanged` for `Content`.
+Do not miss this one:
+
+* **iOS crash fix** -  when simultaineously opening/closing different popups, fix is now the second one would open only after the closing one finished cleaning up.
+* **Android crash fix** - for similar scenario, added the required `(IntPtr, JniHandleOwnership)` JNI resurrection constructor to `MauiPopup`. Without it, `TypeManager.CreateInstance` crashed whenever Android dispatched a touch event to a still-alive native Dialog whose managed C# peer had already been disposed. 
+* **iOS memory leak fix**  - `UITapGestureRecognizer` was leaking.
+* **Windows double-close fix** - `OnClosed` was triggering a second disconnect on every normal close. 
 
 ---
 

--- a/src/Lib/Apple/MauiPopup.macios.cs
+++ b/src/Lib/Apple/MauiPopup.macios.cs
@@ -32,6 +32,7 @@ public partial class MauiPopup(IMauiContext mauiContext) : UIViewController
 	UIView? overlay;
 	UIView? _contentView;
 	PopupDisplayMode _displayMode = PopupDisplayMode.Default;
+	UITapGestureRecognizer? _tapGesture;
 
 	/// <summary>
 	/// The native fullscreen overlay
@@ -219,6 +220,15 @@ public partial class MauiPopup(IMauiContext mauiContext) : UIViewController
 
 		VirtualView = null;
 
+		// Remove and dispose the tap gesture recognizer to break the retain cycle:
+		// View → _tapGesture → lambda closure → this (MauiPopup) → View
+		if (_tapGesture != null)
+		{
+			View?.RemoveGestureRecognizer(_tapGesture);
+			_tapGesture.Dispose();
+			_tapGesture = null;
+		}
+
 		if (PresentationController is UIPopoverPresentationController presentationController)
 		{
 			presentationController.Delegate = null;
@@ -256,7 +266,7 @@ public partial class MauiPopup(IMauiContext mauiContext) : UIViewController
 
 			if (virtualView.CloseWhenBackgroundIsClicked)
 			{
-				var tapGesture = new UITapGestureRecognizer(tapEvent =>
+				_tapGesture = new UITapGestureRecognizer(tapEvent =>
 				{
 					if (CanBeDismissedByTappingInternal && VirtualView is Popup popup && popup.ShouldDismissOnOutsideClick())
 					{
@@ -272,14 +282,13 @@ public partial class MauiPopup(IMauiContext mauiContext) : UIViewController
 
 						// DON'T dismiss here - let the handler flow run the animation first
 						// The actual dismissal will happen in MapOnClosed after animation completes
-						_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null.");
-						VirtualView.Handler?.Invoke(nameof(IPopup.OnDismissedByTappingOutsideOfPopup));
+						VirtualView?.Handler?.Invoke(nameof(IPopup.OnDismissedByTappingOutsideOfPopup));
 					}
 				})
 				{
 					CancelsTouchesInView = false
 				};
-				View.AddGestureRecognizer(tapGesture);
+				View.AddGestureRecognizer(_tapGesture);
 			}
 
 			this.View.InsertSubview(overlay, 0);

--- a/src/Lib/Apple/PopupHandler.macios.cs
+++ b/src/Lib/Apple/PopupHandler.macios.cs
@@ -167,6 +167,12 @@ public partial class PopupHandler : ViewHandler<IPopup, MauiPopupView>
 	/// <inheritdoc/>
 	protected override void DisconnectHandler(MauiPopupView platformView)
 	{
+		// Null out VirtualView on the native side BEFORE disconnecting handlers.
+		// After DisconnectHandler completes, MAUI clears VirtualView.Handler = null on the IPopup.
+		// iOS can still fire ViewDidLayoutSubviews after that, and MauiPopup.VirtualView would
+		// be non-null while VirtualView.Handler is null, causing the MauiContext crash.
+		platformView.Popup?.CleanUp();
+
 		// Disconnect the wrapping PageHandler created in ShowPopup()
 		if (platformView.Control is IElementHandler controlHandler)
 			controlHandler.DisconnectHandler();

--- a/src/Lib/Extensions/PopupExtensions.cs
+++ b/src/Lib/Extensions/PopupExtensions.cs
@@ -186,10 +186,21 @@ internal static IWindow GetWindow(this IElement element) =>
 #endif
     }
 
-    static void CreatePopup(Page page, Popup popup)
+    static async void CreatePopup(Page page, Popup popup)
     {
         if (popup.Handler != null)
             return; // Already showing — ignore duplicate show call.
+
+        // If the topmost popup is actively closing, wait for its full cleanup (animation +
+        // native dismiss + handler disconnect) before presenting the new one.
+        // This prevents iOS cascade-dismissal: if Popup B were presented from Popup A before
+        // Popup A finishes, iOS would auto-dismiss Popup B when Popup A closes.
+        var topPopup = PopupNavigationStack.Instance.Peek();
+        if (topPopup is { IsClosing: true } closingPopup)
+        {
+            try { await ((IAsynchronousHandler)closingPopup).HandlerCompleteTCS.Task; }
+            catch { /* swallow — we still want to show the new popup */ }
+        }
 
         var mauiContext = GetMauiContext(page);
 

--- a/src/Lib/FastPopups.csproj
+++ b/src/Lib/FastPopups.csproj
@@ -21,7 +21,7 @@
     <PackageId>AppoMobi.Maui.FastPopups</PackageId>
     <Description>Popup controls for .NET MAUI derived from CommunityToolkit Popups</Description>
     <PackageTags>fastpopups popups maui popup modal dialog</PackageTags>
-    <Version>1.10.1.1</Version>
+    <Version>1.10.2.1</Version>
     <Authors>Nick Kovalsky aka AppoMobi and contributors</Authors>
     <RepositoryUrl>https://github.com/taublast/popups</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Lib/Platforms/Android/MauiPopup.android.cs
+++ b/src/Lib/Platforms/Android/MauiPopup.android.cs
@@ -25,6 +25,7 @@ namespace FastPopups;
 /// <summary>
 /// The native implementation of Popup control.
 /// </summary>
+[Android.Runtime.Preserve(AllMembers = true)]
 public partial class MauiPopup : Dialog, IDialogInterfaceOnCancelListener
 {
     readonly IMauiContext mauiContext;
@@ -55,6 +56,18 @@ public partial class MauiPopup : Dialog, IDialogInterfaceOnCancelListener
     {
         RequestWindowFeature((int)WindowFeatures.NoTitle);
         this.mauiContext = mauiContext ?? throw new ArgumentNullException(nameof(mauiContext));
+    }
+
+    /// <summary>
+    /// JNI resurrection constructor required by TypeManager.CreateInstance.
+    /// Called when Android dispatches a native callback (e.g. onTouchEvent) to a Java Dialog
+    /// whose managed C# peer was already disposed. Without this constructor TypeManager
+    /// cannot wrap the still-alive Java object and throws JavaProxyThrowable.
+    /// The resurrected instance will have VirtualView == null; all callbacks guard for that.
+    /// </summary>
+    protected MauiPopup(IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer)
+        : base(javaReference, transfer)
+    {
     }
 
     static int GetDialogTheme(PopupDisplayMode displayMode)
@@ -753,10 +766,12 @@ public partial class MauiPopup : Dialog, IDialogInterfaceOnCancelListener
     /// <param name="dialog">An instance of the <see cref="IDialogInterface"/>.</param>
     public void OnDismissedByTappingOutsideOfPopup(IDialogInterface dialog)
     {
-        _ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null");
-        _ = VirtualView.Handler ?? throw new InvalidOperationException($"{nameof(VirtualView.Handler)} cannot be null");
+        // Guard: VirtualView is null on a resurrected instance (managed peer was already
+        // disposed when this callback fired from a still-alive native Dialog)
+        if (VirtualView?.Handler == null)
+            return;
 
-        VirtualView.Handler?.Invoke(nameof(IPopup.OnDismissedByTappingOutsideOfPopup));
+        VirtualView.Handler.Invoke(nameof(IPopup.OnDismissedByTappingOutsideOfPopup));
     }
 
     /// <summary>
@@ -867,6 +882,7 @@ public partial class MauiPopup : Dialog, IDialogInterfaceOnCancelListener
         }
         else
         {
+            SetOnCancelListener(null); // clear so a resurrected instance can't fire OnCancel
             _sizeChangeListener?.Release();
             _sizeChangeListener = null;
             _compositeContainer = null;

--- a/src/Lib/Platforms/Android/PopupHandler.android.cs
+++ b/src/Lib/Platforms/Android/PopupHandler.android.cs
@@ -199,14 +199,16 @@ public partial class PopupHandler : ViewHandler<IPopup, MauiPopupView>
             parent.RemoveView(handler.Content);
         }
 
-        // Properly dismiss and dispose the old dialog
+        // Dismiss the old dialog; do NOT dispose here because Android may still
+        // dispatch queued touch events to the native Dialog after Dismiss() returns,
+        // and disposing the managed peer immediately causes TypeManager.CreateInstance
+        // to crash. The dialog will be disposed when CreateDialog replaces it.
         if (handler.PlatformView.Dialog != null)
         {
             if (handler.PlatformView.Dialog.IsShowing)
             {
-                handler.PlatformView.Dialog.Dismiss(); // Remove from WindowManager first
+                handler.PlatformView.Dialog.Dismiss();
             }
-            handler.PlatformView.Dialog.Dispose(); // Then dispose managed resources
         }
     }
 

--- a/src/Lib/Platforms/Windows/MauiPopup.windows.cs
+++ b/src/Lib/Platforms/Windows/MauiPopup.windows.cs
@@ -106,8 +106,11 @@ public partial class MauiPopup : Microsoft.UI.Xaml.Controls.Grid
     {
         if (element == null)
         {
-            PopupView.IsOpen = false;
+            // Unsubscribe BEFORE setting IsOpen = false — WinUI fires Popup.Closed
+            // synchronously, so leaving the handler attached causes OnClosed to fire
+            // while VirtualView is still set, triggering a spurious double-close.
             PopupView.Closed -= OnClosed;
+            PopupView.IsOpen = false;
 
             try
             {
@@ -123,6 +126,7 @@ public partial class MauiPopup : Microsoft.UI.Xaml.Controls.Grid
             }
 
             VirtualView = null;
+            overlay = null;
 
             if (Content is not null)
             {
@@ -508,7 +512,7 @@ public partial class MauiPopup : Microsoft.UI.Xaml.Controls.Grid
     {
         UpdateLayout();
 
-        if (Content.ActualSize != Vector2.Zero)
+        if (Content?.ActualSize != Vector2.Zero)
         {
             if (!_appeared)
             {

--- a/src/Lib/Views/Popup.cs
+++ b/src/Lib/Views/Popup.cs
@@ -308,6 +308,12 @@ public partial class Popup : View, IPopup
 	public async void Close(object? result = null) => await CloseAsync(result, CancellationToken.None);
 
 	/// <summary>
+	/// Gets a value indicating whether this popup is in the process of closing.
+	/// Used by the presentation queue to avoid showing a new popup before the current one has fully cleaned up.
+	/// </summary>
+	public bool IsClosing { get; private set; }
+
+	/// <summary>
 	/// Close the current popup.
 	/// </summary>
 	/// <remarks>
@@ -317,6 +323,7 @@ public partial class Popup : View, IPopup
 	/// <param name="token"><see cref="CancellationToken"/></param>
 	public async Task CloseAsync(object? result = null, CancellationToken token = default)
 	{
+		IsClosing = true;
 		await OnClosed(result, false, token);
 		resultTaskCompletionSource.TrySetResult(result);
 	}


### PR DESCRIPTION
Do not miss this one:

* **iOS crash fix** -  when simultaineously opening/closing different popups, fix is now the second one would open only after the closing one finished cleaning up.
* **Android crash fix** - for similar scenario, added the required `(IntPtr, JniHandleOwnership)` JNI resurrection constructor to `MauiPopup`. Without it, `TypeManager.CreateInstance` crashed whenever Android dispatched a touch event to a still-alive native Dialog whose managed C# peer had already been disposed. 
* **iOS memory leak fix**  - `UITapGestureRecognizer` was leaking.
* **Windows double-close fix** - `OnClosed` was triggering a second disconnect on every normal close. 
