### PR TITLE
1.10.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,11 @@ Initially built on top of CommunityToolkit popups version one, it was found to b
 - **🔄 HotReload Support**: Preview changes in realtime
 ---
 
-## ⬆️ What's New 1.10.2.1
+## ⬆️ What's New 1.10.2.2
 
-Do not miss this one:
-
-* **iOS crash fix** -  when simultaineously opening/closing different popups, fix is now the second one would open only after the closing one finished cleaning up.
-* **Android crash fix** - for similar scenario, added the required `(IntPtr, JniHandleOwnership)` JNI resurrection constructor to `MauiPopup`. Without it, `TypeManager.CreateInstance` crashed whenever Android dispatched a touch event to a still-alive native Dialog whose managed C# peer had already been disposed. 
-* **iOS memory leak fix**  - `UITapGestureRecognizer` was leaking.
-* **Windows double-close fix** - `OnClosed` was triggering a second disconnect on every normal close. 
-
+* **Popup reuse fix** - `IsClosing` flag was not reset when a popup instance was shown again after closing, causing the presentation queue to stall permanently on reused popups.
+* **Windows animation fix** - `_appeared` could be prematurely set when `Content` was null permanently skipping the show animation.
+* **Stability** - Code paths before the try/catch in `CreatePopup` are now guarded.
 ---
 
 ## Intro

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Initially built on top of CommunityToolkit popups version one, it was found to b
 * **Popup reuse fix** - `IsClosing` flag was not reset when a popup instance was shown again after closing, causing the presentation queue to stall permanently on reused popups.
 * **Windows animation fix** - `_appeared` could be prematurely set when `Content` was null permanently skipping the show animation.
 * **Stability** - Code paths before the try/catch in `CreatePopup` are now guarded.
+* **Creation failure rollback** - If handler creation throws, the popup is now removed from the navigation stack and logical tree, and any awaiting `ShowPopupAsync` call is cancelled instead of hanging indefinitely.
 ---
 
 ## Intro

--- a/src/Lib/Extensions/PopupExtensions.cs
+++ b/src/Lib/Extensions/PopupExtensions.cs
@@ -202,16 +202,16 @@ internal static IWindow GetWindow(this IElement element) =>
             catch { /* swallow — we still want to show the new popup */ }
         }
 
-        var mauiContext = GetMauiContext(page);
-
-        var parent = page.GetCurrentPage();
-        parent?.AddLogicalChild(popup);
-
-        // Add to navigation stack
-        PopupNavigationStack.Instance.Push(popup);
-
         try
         {
+            var mauiContext = GetMauiContext(page);
+
+            var parent = page.GetCurrentPage();
+            parent?.AddLogicalChild(popup);
+
+            // Add to navigation stack
+            PopupNavigationStack.Instance.Push(popup);
+
             var platformPopup = popup.ToHandler(mauiContext);
 
             platformPopup.Invoke(nameof(IPopup.OnOpened));

--- a/src/Lib/Extensions/PopupExtensions.cs
+++ b/src/Lib/Extensions/PopupExtensions.cs
@@ -202,11 +202,12 @@ internal static IWindow GetWindow(this IElement element) =>
             catch { /* swallow — we still want to show the new popup */ }
         }
 
+        Page? parent = null;
         try
         {
             var mauiContext = GetMauiContext(page);
 
-            var parent = page.GetCurrentPage();
+            parent = page.GetCurrentPage();
             parent?.AddLogicalChild(popup);
 
             // Add to navigation stack
@@ -219,6 +220,10 @@ internal static IWindow GetWindow(this IElement element) =>
         catch (Exception e)
         {
             Trace.WriteLine(e);
+            // Roll back partial state so the queue doesn't stall on a popup that never opened.
+            parent?.RemoveLogicalChild(popup);
+            PopupNavigationStack.Instance.Remove(popup);
+            popup.OnCreationFailed();
         }
     }
 

--- a/src/Lib/FastPopups.csproj
+++ b/src/Lib/FastPopups.csproj
@@ -21,7 +21,7 @@
     <PackageId>AppoMobi.Maui.FastPopups</PackageId>
     <Description>Popup controls for .NET MAUI derived from CommunityToolkit Popups</Description>
     <PackageTags>fastpopups popups maui popup modal dialog</PackageTags>
-    <Version>1.10.2.1</Version>
+    <Version>1.10.2.2</Version>
     <Authors>Nick Kovalsky aka AppoMobi and contributors</Authors>
     <RepositoryUrl>https://github.com/taublast/popups</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Lib/Platforms/Windows/MauiPopup.windows.cs
+++ b/src/Lib/Platforms/Windows/MauiPopup.windows.cs
@@ -512,7 +512,7 @@ public partial class MauiPopup : Microsoft.UI.Xaml.Controls.Grid
     {
         UpdateLayout();
 
-        if (Content?.ActualSize != Vector2.Zero)
+        if (Content != null && Content.ActualSize != Vector2.Zero)
         {
             if (!_appeared)
             {

--- a/src/Lib/Views/Popup.cs
+++ b/src/Lib/Views/Popup.cs
@@ -291,6 +291,7 @@ public partial class Popup : View, IPopup
 		{
 			// New handler assigned means popup is being shown (fresh or re-shown).
 			// Auto-reset TCS so Result and internal completion are clean.
+			IsClosing = false;
 			resultTaskCompletionSource = new();
 			popupDismissedTaskCompletionSource = new();
 		}

--- a/src/Lib/Views/Popup.cs
+++ b/src/Lib/Views/Popup.cs
@@ -315,6 +315,16 @@ public partial class Popup : View, IPopup
 	public bool IsClosing { get; private set; }
 
 	/// <summary>
+	/// Called by the presentation layer when handler creation fails so that any awaiting
+	/// <see cref="Result"/> task is cancelled rather than hanging indefinitely.
+	/// </summary>
+	internal void OnCreationFailed()
+	{
+		resultTaskCompletionSource.TrySetCanceled();
+		popupDismissedTaskCompletionSource.TrySetCanceled();
+	}
+
+	/// <summary>
 	/// Close the current popup.
 	/// </summary>
 	/// <remarks>


### PR DESCRIPTION
* **Popup reuse fix** - `IsClosing` flag was not reset when a popup instance was shown again after closing, causing the presentation queue to stall permanently on reused popups.
* **Windows animation fix** - `_appeared` could be prematurely set when `Content` was null permanently skipping the show animation.
* **Stability** - Code paths before the try/catch in `CreatePopup` are now guarded.
